### PR TITLE
Test: TasksService, ImporterService, ValidatorService

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,7 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
-    branches: [ main ]
-    types: [ opened ]
+  pull_request: {}
 
 jobs:
   main:
@@ -31,20 +29,17 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       
       - name: npm install
         run: npm ci
-
-      - name: npm lint
-        run: npm run lint
 
       - name: unit test
         run: npm run test

--- a/src/tasks/pair-liquidity-info-history-importer.service.spec.ts
+++ b/src/tasks/pair-liquidity-info-history-importer.service.spec.ts
@@ -4,7 +4,6 @@ import { MdwClientService } from '../clients/mdw-client.service';
 import { PairService } from '../database/pair.service';
 import { PairLiquidityInfoHistoryService } from '../database/pair-liquidity-info-history.service';
 import { PairLiquidityInfoHistoryErrorService } from '../database/pair-liquidity-info-history-error.service';
-import { Logger } from '@nestjs/common';
 import { ContractAddress } from '../lib/utils';
 import { Contract } from '../clients/mdw-client.model';
 
@@ -46,7 +45,6 @@ describe('PairLiquidityInfoHistoryImporterService', () => {
           provide: PairLiquidityInfoHistoryErrorService,
           useValue: mockPairLiquidityInfoHistoryErrorService,
         },
-        { provide: Logger, useValue: jest.fn() }, // Mock Logger if necessary
       ],
     }).compile();
     service = module.get<PairLiquidityInfoHistoryImporterService>(
@@ -55,7 +53,7 @@ describe('PairLiquidityInfoHistoryImporterService', () => {
   });
 
   describe('import', () => {
-    it('should execute correctly', async () => {
+    it('should import liquidity correctly', async () => {
       // Mock data
       const pair1 = {
         id: 1,
@@ -152,7 +150,7 @@ describe('PairLiquidityInfoHistoryImporterService', () => {
         `Completed sync for pair ${pair1.id} ${pair1.address}. Synced 2 micro block(s).`,
       );
       expect(service.logger.log).toHaveBeenCalledWith(
-        `Finished liquidity info history sync for all pairs.`,
+        'Finished liquidity info history sync for all pairs.',
       );
     });
   });

--- a/src/tasks/pair-liquidity-info-history-importer.service.spec.ts
+++ b/src/tasks/pair-liquidity-info-history-importer.service.spec.ts
@@ -1,0 +1,159 @@
+import { PairLiquidityInfoHistoryImporterService } from './pair-liquidity-info-history-importer.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MdwClientService } from '../clients/mdw-client.service';
+import { PairService } from '../database/pair.service';
+import { PairLiquidityInfoHistoryService } from '../database/pair-liquidity-info-history.service';
+import { PairLiquidityInfoHistoryErrorService } from '../database/pair-liquidity-info-history-error.service';
+import { Logger } from '@nestjs/common';
+import { ContractAddress } from '../lib/utils';
+import { Contract } from '../clients/mdw-client.model';
+
+const mockMdwClientService = {
+  getContract: jest.fn(),
+  getMicroBlock: jest.fn(),
+  getContractLogsUntilCondition: jest.fn(),
+  getContractBalancesAtMicroBlockHashV1: jest.fn(),
+  getAccountBalanceForContractAtMicroBlockHash: jest.fn(),
+};
+
+const mockPairService = {
+  getAll: jest.fn(),
+};
+
+const mockPairLiquidityInfoHistoryService = {
+  getLastlySyncedBlockByPairId: jest.fn(),
+  upsert: jest.fn(),
+};
+
+const mockPairLiquidityInfoHistoryErrorService = {
+  getErrorByPairIdAndMicroBlockHashWithinHours: jest.fn(),
+};
+
+describe('PairLiquidityInfoHistoryImporterService', () => {
+  let service: PairLiquidityInfoHistoryImporterService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PairLiquidityInfoHistoryImporterService,
+        { provide: MdwClientService, useValue: mockMdwClientService },
+        { provide: PairService, useValue: mockPairService },
+        {
+          provide: PairLiquidityInfoHistoryService,
+          useValue: mockPairLiquidityInfoHistoryService,
+        },
+        {
+          provide: PairLiquidityInfoHistoryErrorService,
+          useValue: mockPairLiquidityInfoHistoryErrorService,
+        },
+        { provide: Logger, useValue: jest.fn() }, // Mock Logger if necessary
+      ],
+    }).compile();
+    service = module.get<PairLiquidityInfoHistoryImporterService>(
+      PairLiquidityInfoHistoryImporterService,
+    );
+  });
+
+  describe('import', () => {
+    it('should execute correctly', async () => {
+      // Mock data
+      const pair1 = {
+        id: 1,
+        address: 'ct_pair' as ContractAddress,
+        token0: { address: 'ct_token0' },
+        token1: { address: 'ct_token1' },
+      };
+      const pair1Contract: Contract = {
+        aexn_type: '',
+        block_hash: 'mh_hash0',
+        contract: pair1.address,
+        source_tx_hash: 'th_',
+        source_tx_type: '',
+        create_tx: {},
+      };
+      const initialMicroBlock = {
+        hash: pair1Contract.block_hash,
+        height: '10000',
+        time: '1000000000000',
+      };
+      const pairContractLog1 = {
+        block_time: '1000000000001',
+        block_hash: 'mh_hash1',
+        height: '10001',
+      };
+      const pairContractLog2 = {
+        block_time: '1000000000002',
+        block_hash: 'mh_hash2',
+        height: '10002',
+      };
+
+      // Mock functions
+      mockPairService.getAll.mockResolvedValue([pair1]);
+      mockPairLiquidityInfoHistoryErrorService.getErrorByPairIdAndMicroBlockHashWithinHours.mockResolvedValue(
+        undefined,
+      );
+      mockPairLiquidityInfoHistoryService.getLastlySyncedBlockByPairId.mockReturnValue(
+        undefined,
+      );
+      mockMdwClientService.getContract.mockResolvedValue(pair1Contract);
+      mockMdwClientService.getMicroBlock.mockResolvedValue(initialMicroBlock);
+      mockPairLiquidityInfoHistoryService.upsert.mockResolvedValue(null);
+      mockMdwClientService.getContractLogsUntilCondition.mockResolvedValue([
+        pairContractLog1,
+        pairContractLog2,
+      ]);
+      mockMdwClientService.getContractBalancesAtMicroBlockHashV1.mockResolvedValue(
+        { amounts: { ak_a: '1', ak_b: '1' } },
+      );
+      mockMdwClientService.getAccountBalanceForContractAtMicroBlockHash.mockResolvedValue(
+        { amount: '1' },
+      );
+      jest.spyOn(service.logger, 'log');
+
+      // Start import
+      await service.import();
+
+      // Assertions
+      // Insert initial liquidity
+      expect(mockPairLiquidityInfoHistoryService.upsert).toHaveBeenCalledWith({
+        pairId: pair1.id,
+        totalSupply: '0',
+        reserve0: '0',
+        reserve1: '0',
+        height: parseInt(initialMicroBlock.height),
+        microBlockHash: initialMicroBlock.hash,
+        microBlockTime: BigInt(initialMicroBlock.time),
+      });
+      expect(
+        mockPairLiquidityInfoHistoryErrorService.getErrorByPairIdAndMicroBlockHashWithinHours,
+      ).toHaveBeenCalledTimes(3);
+      expect(service.logger.log).toHaveBeenCalledWith(
+        `Started syncing pair ${pair1.id} ${pair1.address}. Need to sync 2 micro block(s). This can take some time.`,
+      );
+      expect(mockPairLiquidityInfoHistoryService.upsert).toHaveBeenCalledWith({
+        pairId: pair1.id,
+        totalSupply: '2',
+        reserve0: '1',
+        reserve1: '1',
+        height: parseInt(pairContractLog1.height),
+        microBlockHash: pairContractLog1.block_hash,
+        microBlockTime: BigInt(pairContractLog1.block_time),
+      });
+      expect(mockPairLiquidityInfoHistoryService.upsert).toHaveBeenCalledWith({
+        pairId: pair1.id,
+        totalSupply: '2',
+        reserve0: '1',
+        reserve1: '1',
+        height: parseInt(pairContractLog2.height),
+        microBlockHash: pairContractLog2.block_hash,
+        microBlockTime: BigInt(pairContractLog2.block_time),
+      });
+      expect(service.logger.log).toHaveBeenCalledWith(
+        `Completed sync for pair ${pair1.id} ${pair1.address}. Synced 2 micro block(s).`,
+      );
+      expect(service.logger.log).toHaveBeenCalledWith(
+        `Finished liquidity info history sync for all pairs.`,
+      );
+    });
+  });
+});

--- a/src/tasks/pair-liquidity-info-history-importer.service.ts
+++ b/src/tasks/pair-liquidity-info-history-importer.service.ts
@@ -191,7 +191,7 @@ export class PairLiquidityInfoHistoryImporterService {
       }
     }
 
-    this.logger.log(`Finished liquidity info history sync for all pairs.`);
+    this.logger.log('Finished liquidity info history sync for all pairs.');
   }
 
   private async insertInitialLiquidity(pairWithTokens: PairWithTokens) {

--- a/src/tasks/pair-liquidity-info-history-validator.service.spec.ts
+++ b/src/tasks/pair-liquidity-info-history-validator.service.spec.ts
@@ -1,0 +1,110 @@
+import { PairLiquidityInfoHistoryValidatorService } from './pair-liquidity-info-history-validator.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MdwClientService } from '../clients/mdw-client.service';
+import { PairLiquidityInfoHistoryService } from '../database/pair-liquidity-info-history.service';
+
+const mockMdwClientService = {
+  getKeyBlockMicroBlocks: jest.fn(),
+};
+
+const mockPairLiquidityInfoHistoryService = {
+  getWithinHeightSorted: jest.fn(),
+  deleteFromMicroBlockTime: jest.fn(),
+};
+
+describe('PairLiquidityInfoHistoryValidatorService', () => {
+  let service: PairLiquidityInfoHistoryValidatorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PairLiquidityInfoHistoryValidatorService,
+        { provide: MdwClientService, useValue: mockMdwClientService },
+        {
+          provide: PairLiquidityInfoHistoryService,
+          useValue: mockPairLiquidityInfoHistoryService,
+        },
+      ],
+    }).compile();
+    service = module.get<PairLiquidityInfoHistoryValidatorService>(
+      PairLiquidityInfoHistoryValidatorService,
+    );
+  });
+
+  describe('validate', () => {
+    it('should validate history correctly', async () => {
+      // Mock data
+      const historyEntry1 = {
+        height: 10001,
+        microBlockTime: 1000000000001n,
+        microBlockHash: 'mh_hash1',
+      };
+      const historyEntry2 = {
+        height: 10001,
+        microBlockTime: 1000000000002n,
+        microBlockHash: 'mh_hash2',
+      };
+      const historyEntry3 = {
+        height: 10003,
+        microBlockTime: 1000000000003n,
+        microBlockHash: 'mh_hash3',
+      };
+      const historyEntry4 = {
+        height: 10004,
+        microBlockTime: 1000000000004n,
+        microBlockHash: 'mh_hash4',
+      };
+      const historyEntry5 = {
+        height: 10005,
+        microBlockTime: 1000000000005n,
+        microBlockHash: 'mh_hash5',
+      };
+      // Mock functions
+      mockPairLiquidityInfoHistoryService.getWithinHeightSorted.mockResolvedValue(
+        [historyEntry1, historyEntry2, historyEntry3, historyEntry4],
+      );
+      mockMdwClientService.getKeyBlockMicroBlocks.mockImplementation(
+        (height: number) => {
+          if (height === historyEntry1.height) {
+            return [
+              { hash: historyEntry1.microBlockHash },
+              { hash: historyEntry2.microBlockHash },
+              { hash: 'mh_xyz' },
+            ];
+          } else if (height === historyEntry3.height) {
+            return [{ hash: historyEntry3.microBlockHash }, { hash: 'mh_xyz' }];
+          } else {
+            return [];
+          }
+        },
+      );
+      mockPairLiquidityInfoHistoryService.deleteFromMicroBlockTime.mockResolvedValue(
+        { count: 2 },
+      );
+      jest.spyOn(service.logger, 'log');
+
+      // Start validation
+      await service.validate();
+
+      // Assertions
+      expect(mockMdwClientService.getKeyBlockMicroBlocks).toHaveBeenCalledWith(
+        historyEntry1.height,
+      );
+      expect(mockMdwClientService.getKeyBlockMicroBlocks).toHaveBeenCalledWith(
+        historyEntry3.height,
+      );
+      expect(mockMdwClientService.getKeyBlockMicroBlocks).toHaveBeenCalledWith(
+        historyEntry4.height,
+      );
+      expect(
+        mockMdwClientService.getKeyBlockMicroBlocks,
+      ).not.toHaveBeenCalledWith(historyEntry5.height);
+      expect(
+        mockPairLiquidityInfoHistoryService.deleteFromMicroBlockTime,
+      ).toHaveBeenCalledWith(historyEntry4.microBlockTime);
+      expect(service.logger.log).toHaveBeenCalledWith(
+        `Found an inconsistency in pair liquidity info history. Deleted 2 entries.`,
+      );
+    });
+  });
+});

--- a/src/tasks/pair-liquidity-info-history-validator.service.ts
+++ b/src/tasks/pair-liquidity-info-history-validator.service.ts
@@ -2,40 +2,19 @@ import { MdwClientService } from '../clients/mdw-client.service';
 import { PairLiquidityInfoHistoryService } from '../database/pair-liquidity-info-history.service';
 import { Injectable, Logger } from '@nestjs/common';
 import { uniq } from 'lodash';
-import { Cron } from '@nestjs/schedule';
 import { getClient } from '../lib/contracts';
 import { MicroBlockHash } from '../lib/utils';
-import { TasksService } from './tasks.service';
-
-const EVERY_5_MINUTES_STARTING_AT_02_30 = '30 2-57/5 * * * *';
 
 @Injectable()
 export class PairLiquidityInfoHistoryValidatorService {
   constructor(
-    private tasksService: TasksService,
     private mdwClientService: MdwClientService,
     private pairLiquidityInfoHistoryService: PairLiquidityInfoHistoryService,
   ) {}
 
-  private readonly logger = new Logger(
-    PairLiquidityInfoHistoryValidatorService.name,
-  );
+  readonly logger = new Logger(PairLiquidityInfoHistoryValidatorService.name);
 
-  @Cron(EVERY_5_MINUTES_STARTING_AT_02_30)
-  async runTask() {
-    try {
-      if (!this.tasksService.isRunning) {
-        this.tasksService.setIsRunning(true);
-        await this.validatePairLiquidityInfoHistory();
-        this.tasksService.setIsRunning(false);
-      }
-    } catch (error) {
-      this.logger.error(`Validation failed. ${error}`);
-      this.tasksService.setIsRunning(false);
-    }
-  }
-
-  async validatePairLiquidityInfoHistory() {
+  async validate() {
     this.logger.log(`Started validating pair liquidity info history.`);
 
     // Get current height

--- a/src/tasks/pair-liquidity-info-history-validator.service.ts
+++ b/src/tasks/pair-liquidity-info-history-validator.service.ts
@@ -66,9 +66,9 @@ export class PairLiquidityInfoHistoryValidatorService {
         `Found an inconsistency in pair liquidity info history. Deleted ${numDeleted} entries.`,
       );
     } else {
-      this.logger.log(`No problems in pair liquidity info history found.`);
+      this.logger.log('No problems in pair liquidity info history found.');
     }
 
-    this.logger.log(`Finished validating pair liquidity info history.`);
+    this.logger.log('Finished validating pair liquidity info history.');
   }
 }

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TasksService } from './tasks.service';
+import { PairLiquidityInfoHistoryImporterService } from './pair-liquidity-info-history-importer.service';
+import { PairLiquidityInfoHistoryValidatorService } from './pair-liquidity-info-history-validator.service';
+import { MdwClientService } from '../clients/mdw-client.service';
+import { PairService } from '../database/pair.service';
+import { PairLiquidityInfoHistoryService } from '../database/pair-liquidity-info-history.service';
+import { PairLiquidityInfoHistoryErrorService } from '../database/pair-liquidity-info-history-error.service';
+import { PrismaService } from '../database/prisma.service';
+
+describe('TasksService', () => {
+  let tasksService: TasksService;
+  let pairLiquidityInfoHistoryImporterService: PairLiquidityInfoHistoryImporterService;
+  let pairLiquidityInfoHistoryValidatorService: PairLiquidityInfoHistoryValidatorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        PairLiquidityInfoHistoryImporterService,
+        PairLiquidityInfoHistoryValidatorService,
+        MdwClientService,
+        PairService,
+        PairLiquidityInfoHistoryService,
+        PairLiquidityInfoHistoryErrorService,
+        PrismaService,
+      ],
+    }).compile();
+
+    tasksService = module.get<TasksService>(TasksService);
+    pairLiquidityInfoHistoryImporterService =
+      module.get<PairLiquidityInfoHistoryImporterService>(
+        PairLiquidityInfoHistoryImporterService,
+      );
+    pairLiquidityInfoHistoryValidatorService =
+      module.get<PairLiquidityInfoHistoryValidatorService>(
+        PairLiquidityInfoHistoryValidatorService,
+      );
+  });
+
+  describe('runPairLiquidityInfoHistoryImporter', () => {
+    it('should run if no task is running', async () => {
+      jest
+        .spyOn(pairLiquidityInfoHistoryImporterService, 'import')
+        .mockResolvedValue();
+
+      await tasksService.runPairLiquidityInfoHistoryImporter();
+      expect(pairLiquidityInfoHistoryImporterService.import).toHaveBeenCalled();
+      expect(tasksService.isRunning).toBe(false);
+    });
+
+    it('should not run if a task is running already', async () => {
+      tasksService.setIsRunning(true);
+      jest.spyOn(pairLiquidityInfoHistoryImporterService, 'import');
+      await tasksService.runPairLiquidityInfoHistoryImporter();
+      expect(
+        pairLiquidityInfoHistoryImporterService.import,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should handle error correctly', async () => {
+      const error = new Error('Test Error');
+      jest
+        .spyOn(pairLiquidityInfoHistoryImporterService, 'import')
+        .mockRejectedValue(error);
+      jest.spyOn(pairLiquidityInfoHistoryImporterService.logger, 'error');
+
+      await tasksService.runPairLiquidityInfoHistoryImporter();
+      expect(
+        pairLiquidityInfoHistoryImporterService.logger.error,
+      ).toHaveBeenCalledWith(`Import failed. ${error}`);
+      expect(tasksService.isRunning).toBe(false);
+    });
+  });
+
+  describe('runPairLiquidityInfoHistoryValidator', () => {
+    it('should run if no task is running', async () => {
+      jest
+        .spyOn(pairLiquidityInfoHistoryValidatorService, 'validate')
+        .mockResolvedValue();
+
+      await tasksService.runPairLiquidityInfoHistoryValidator();
+      expect(
+        pairLiquidityInfoHistoryValidatorService.validate,
+      ).toHaveBeenCalled();
+    });
+
+    it('should not run if a task is running already', async () => {
+      tasksService.setIsRunning(true);
+
+      jest.spyOn(pairLiquidityInfoHistoryValidatorService, 'validate');
+
+      await tasksService.runPairLiquidityInfoHistoryValidator();
+      expect(
+        pairLiquidityInfoHistoryValidatorService.validate,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should handle error correctly', async () => {
+      const error = new Error('Test Error');
+      jest
+        .spyOn(pairLiquidityInfoHistoryValidatorService, 'validate')
+        .mockRejectedValue(error);
+      jest.spyOn(pairLiquidityInfoHistoryValidatorService.logger, 'error');
+
+      await tasksService.runPairLiquidityInfoHistoryValidator();
+      expect(
+        pairLiquidityInfoHistoryValidatorService.logger.error,
+      ).toHaveBeenCalledWith(`Validation failed. ${error}`);
+      expect(tasksService.isRunning).toBe(false);
+    });
+  });
+});

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -1,7 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PairLiquidityInfoHistoryImporterService } from './pair-liquidity-info-history-importer.service';
+import { PairLiquidityInfoHistoryValidatorService } from './pair-liquidity-info-history-validator.service';
+
+const EVERY_5_MINUTES_STARTING_AT_02_30 = '30 2-57/5 * * * *';
 
 @Injectable()
 export class TasksService {
+  constructor(
+    private pairLiquidityInfoHistoryImporterService: PairLiquidityInfoHistoryImporterService,
+    private pairLiquidityInfoHistoryValidatorService: PairLiquidityInfoHistoryValidatorService,
+  ) {}
+
   private _isRunning = false;
 
   get isRunning(): boolean {
@@ -10,5 +20,37 @@ export class TasksService {
 
   setIsRunning(isRunning: boolean): void {
     this._isRunning = isRunning;
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async runPairLiquidityInfoHistoryImporter() {
+    try {
+      if (!this.isRunning) {
+        this.setIsRunning(true);
+        await this.pairLiquidityInfoHistoryImporterService.import();
+        this.setIsRunning(false);
+      }
+    } catch (error) {
+      this.pairLiquidityInfoHistoryImporterService.logger.error(
+        `Import failed. ${error}`,
+      );
+      this.setIsRunning(false);
+    }
+  }
+
+  @Cron(EVERY_5_MINUTES_STARTING_AT_02_30)
+  async runPairLiquidityInfoHistoryValidator() {
+    try {
+      if (!this.isRunning) {
+        this.setIsRunning(true);
+        await this.pairLiquidityInfoHistoryValidatorService.validate();
+        this.setIsRunning(false);
+      }
+    } catch (error) {
+      this.pairLiquidityInfoHistoryValidatorService.logger.error(
+        `Validation failed. ${error}`,
+      );
+      this.setIsRunning(false);
+    }
   }
 }

--- a/test/pairs.e2e-spec.ts
+++ b/test/pairs.e2e-spec.ts
@@ -1,11 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from '../src/app.module';
-import { mockContext, listToken, sortByAddress } from './utils';
+import { listToken, mockContext, sortByAddress } from './utils';
 import createWorkerMethods from '../src/worker';
 import * as data from './data/context-mockups';
 import * as db from './utils/db';
+import { TokensModule } from '../src/api/tokens/module';
+import { PairsModule } from '../src/api/pairs/module';
 
 type WorkerMethods = ReturnType<typeof createWorkerMethods>;
 let activeWorker: WorkerMethods;
@@ -29,7 +30,7 @@ describe('pairs fetching (e2e)', () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TokensModule, PairsModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/test/swap-routes.e2e-spec.ts
+++ b/test/swap-routes.e2e-spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from '../src/app.module';
 
-import { mockContext, listToken } from './utils';
+import { listToken, mockContext } from './utils';
 import worker from '../src/worker';
 import * as db from './utils/db';
 import * as data from './data/context-mockups';
+import { TokensModule } from '../src/api/tokens/module';
+import { PairsModule } from '../src/api/pairs/module';
 
 type WorkerMethods = ReturnType<typeof worker>;
 let activeWorker: WorkerMethods;
@@ -28,7 +29,7 @@ const initWorker = async (dataCtx: any) => {
 
 const initApp = async () => {
   const moduleFixture: TestingModule = await Test.createTestingModule({
-    imports: [AppModule],
+    imports: [TokensModule, PairsModule],
   }).compile();
 
   app = moduleFixture.createNestApplication();

--- a/test/tokens.e2e-spec.ts
+++ b/test/tokens.e2e-spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from '../src/app.module';
 
 import worker from '../src/worker';
 import { clean as cleanDb } from './utils/db';
@@ -9,6 +8,8 @@ import * as data from './data/context-mockups';
 import * as dto from '../src/dto';
 import * as utils from './utils';
 import { nonNullable } from '../src/lib/utils';
+import { TokensModule } from '../src/api/tokens/module';
+import { PairsModule } from '../src/api/pairs/module';
 
 type WorkerMethods = ReturnType<typeof worker>;
 let activeWorker: WorkerMethods;
@@ -32,7 +33,7 @@ describe('tokens fetching (e2e)', () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TokensModule, PairsModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
@@ -486,7 +487,7 @@ describe('listed tokens management (e2e)', () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TokensModule, PairsModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();


### PR DESCRIPTION
- Moved task running logic (including blocking) to `TasksService`
- Implemented unit tests for `TasksService`, `ImporterService` and `ValidatorService`
- Adjustet `workflows/test.yml`:
  - Run tests on PR lvl
  - Remove lint step (already part of `lint.yml`)
- Fixed e2e tests: Previously the `AppModule` (which includes the `TasksModule`) was imported in the e2e tests leading to the execution of the CronJobs and the failure of the tests. We now import only the necessary modules.