### PR TITLE
Refactor: Get contract balances v1 to v2

### DIFF
--- a/src/clients/mdw-client.model.ts
+++ b/src/clients/mdw-client.model.ts
@@ -48,11 +48,14 @@ export type AccountBalance = {
   contract: ContractAddress;
 };
 
-export type BalancesV1 = {
-  amounts: Record<AccountAddress, string>;
+export type ContractBalance = {
+  account_id: AccountAddress;
+  amount: string;
   block_hash: MicroBlockHash;
   contract_id: ContractAddress;
   height: string;
+  last_log_idx: string;
+  last_tx_hash: TxHash;
 };
 
 export type MdwMicroBlock = {

--- a/src/clients/mdw-client.service.ts
+++ b/src/clients/mdw-client.service.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/utils';
 import {
   AccountBalance,
-  BalancesV1,
+  ContractBalance,
   Contract,
   ContractLog,
   MdwMicroBlock,
@@ -45,6 +45,15 @@ export class MdwClientService {
     );
   }
 
+  getContractBalancesAtMicroBlockHash(
+    contractAddress: ContractAddress,
+    microBlockHash: MicroBlockHash,
+  ): Promise<ContractBalance[]> {
+    return this.getAllPages<ContractBalance>(
+      `/v2/aex9/${contractAddress}/balances/?block_hash=${microBlockHash}&${this.defaultParams}`,
+    );
+  }
+
   getAccountBalanceForContractAtMicroBlockHash(
     contractAddress: ContractAddress,
     accountAddress: AccountAddress,
@@ -58,15 +67,6 @@ export class MdwClientService {
   getMicroBlock(microBlockHash: MicroBlockHash): Promise<MdwMicroBlock> {
     return this.get<MdwMicroBlock>(
       `/v2/micro-blocks/${microBlockHash}?${this.defaultParams}`,
-    );
-  }
-
-  getContractBalancesAtMicroBlockHashV1(
-    contractAddress: ContractAddress,
-    microBlockHash: MicroBlockHash,
-  ): Promise<BalancesV1> {
-    return this.get<BalancesV1>(
-      `/aex9/balances/hash/${microBlockHash}/${contractAddress}?${this.defaultParams}`,
     );
   }
 

--- a/src/tasks/pair-liquidity-info-history-importer.service.spec.ts
+++ b/src/tasks/pair-liquidity-info-history-importer.service.spec.ts
@@ -11,7 +11,7 @@ const mockMdwClientService = {
   getContract: jest.fn(),
   getMicroBlock: jest.fn(),
   getContractLogsUntilCondition: jest.fn(),
-  getContractBalancesAtMicroBlockHashV1: jest.fn(),
+  getContractBalancesAtMicroBlockHash: jest.fn(),
   getAccountBalanceForContractAtMicroBlockHash: jest.fn(),
 };
 
@@ -100,8 +100,8 @@ describe('PairLiquidityInfoHistoryImporterService', () => {
         pairContractLog1,
         pairContractLog2,
       ]);
-      mockMdwClientService.getContractBalancesAtMicroBlockHashV1.mockResolvedValue(
-        { amounts: { ak_a: '1', ak_b: '1' } },
+      mockMdwClientService.getContractBalancesAtMicroBlockHash.mockResolvedValue(
+        [{ amount: '1' }, { amount: '1' }],
       );
       mockMdwClientService.getAccountBalanceForContractAtMicroBlockHash.mockResolvedValue(
         { amount: '1' },

--- a/src/tasks/pair-liquidity-info-history-importer.service.ts
+++ b/src/tasks/pair-liquidity-info-history-importer.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { MdwClientService } from '../clients/mdw-client.service';
 import { PairService, PairWithTokens } from '../database/pair.service';
-import { isEqual, orderBy, uniqWith, values } from 'lodash';
+import { isEqual, orderBy, uniqWith } from 'lodash';
 import { PairLiquidityInfoHistoryService } from '../database/pair-liquidity-info-history.service';
 import {
   ContractAddress,
@@ -223,12 +223,12 @@ export class PairLiquidityInfoHistoryImporterService {
   ) {
     // Total supply is the sum of all amounts of the pair contract's balances
     const pairBalances =
-      await this.mdwClientService.getContractBalancesAtMicroBlockHashV1(
+      await this.mdwClientService.getContractBalancesAtMicroBlockHash(
         pairWithTokens.address as ContractAddress,
         block.hash,
       );
-    const totalSupply = values(pairBalances.amounts)
-      .map((amount) => BigInt(amount))
+    const totalSupply = pairBalances
+      .map((contractBalance) => BigInt(contractBalance.amount))
       .reduce((a, b) => a + b, 0n);
 
     // reserve0 is the balance of the pair contract's account of token0


### PR DESCRIPTION
- Migrated middleware `getContractBalancesAtMicroBlockHash` to v2 endpoint