### PR TITLE
Fix(history-importer): Move check for recent log error to correct place

### DIFF
--- a/src/tasks/pair-liquidity-info-history-importer/pair-liquidity-info-history-importer.service.spec.ts
+++ b/src/tasks/pair-liquidity-info-history-importer/pair-liquidity-info-history-importer.service.spec.ts
@@ -142,7 +142,7 @@ describe('PairLiquidityInfoHistoryImporterService', () => {
 
       expect(
         mockPairLiquidityInfoHistoryErrorDb.getErrorWithinHours,
-      ).toHaveBeenCalledTimes(5); // Once for pair and 4 times for each inserted event
+      ).toHaveBeenCalledTimes(8); // Once for pair and 7 times for each (relevant) event log
 
       expect(mockPairLiquidityInfoHistoryDb.upsert).toHaveBeenCalledTimes(5);
       expect(
@@ -235,7 +235,7 @@ describe('PairLiquidityInfoHistoryImporterService', () => {
 
       expect(
         mockPairLiquidityInfoHistoryErrorDb.getErrorWithinHours,
-      ).toHaveBeenCalledTimes(3); // Once for pair and 2 times for each event
+      ).toHaveBeenCalledTimes(5); // Once for pair and 4 times for each event log
 
       expect(
         mockPairLiquidityInfoHistoryDb.upsert.mock.calls,


### PR DESCRIPTION
- ATM the check is only made after every logic for a log is already executed, which doesn't make much sense
- Moved the check at the start of the logic executed for every log, so it really skips the execution if a recent error occured